### PR TITLE
[FE] 가상돔 적용 + 전역 상태 관리를 위한 옵저버 패턴 적용

### DIFF
--- a/client/src/apis/api.ts
+++ b/client/src/apis/api.ts
@@ -4,21 +4,18 @@ export const RES_FAIL: number = 400;
 export const RES_FAIL_REDIRECTION: number = 401;
 export const RES_FAIL_ALERT: number = 402;
 
-enum Method {
-  GET = 'GET',
-  POST = 'POST',
-  PUT = 'PUT',
-  DELETE = 'DELETE',
-}
+const Method = {
+  GET: 'GET',
+  POST: 'POST',
+  PUT: 'PUT',
+  DELETE: 'DELETE',
+} as const;
+
+type Method = typeof Method[keyof typeof Method];
 
 const END_POINT = 'http://localhost:8000';
 
-const useFetch = (
-  url: string,
-  callBack: Function,
-  method: Method,
-  body?: {},
-) => {
+const useFetch = async (url: string, method: Method, body?: {}) => {
   const option = {
     method: method,
     headers: {
@@ -29,44 +26,45 @@ const useFetch = (
   };
 
   const URL = END_POINT + url;
-  let resStatus = RES_SUCCESS;
 
-  fetch(URL, option as RequestInit)
-    .then(res => {
-      resStatus = res.status;
-      return res.json();
-    })
-    .then((data: any) => {
-      switch (resStatus) {
-        case RES_FAIL:
-          throw new Error(data.message);
-        case RES_FAIL_REDIRECTION:
-          //window.location.href = `#${Path.signIn}`;
-          throw new Error(data.message);
-        case RES_FAIL_ALERT:
-          alert(data.message);
-          throw new Error(data.message);
-        case RES_SUCCESS:
-          callBack(data);
-          break;
-      }
-    })
-    .catch(e => {
-      console.error(e.message);
-    });
-};
-export const GET = (url: string, callBack: Function) => {
-  useFetch(url, callBack, Method.GET);
-};
+  try {
+    let statusCode = RES_SUCCESS;
 
-export const POST = (url: string, callBack: Function, body?: {}) => {
-  useFetch(url, callBack, Method.POST, body);
+    const res = await fetch(URL, option as RequestInit);
+
+    statusCode = res.status;
+
+    const data = await res.json();
+
+    switch (statusCode) {
+      case RES_FAIL:
+        throw new Error(data.message);
+      case RES_FAIL_REDIRECTION:
+        //window.location.href = `#${Path.signIn}`;
+        throw new Error(data.message);
+      case RES_FAIL_ALERT:
+        alert(data.message);
+        throw new Error(data.message);
+      case RES_SUCCESS:
+        return data;
+    }
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};
+export const GET = async (url: string) => {
+  return await useFetch(url, Method.GET);
 };
 
-export const PUT = (url: string, callBack: Function, body?: {}) => {
-  useFetch(url, callBack, Method.PUT, body);
+export const POST = async (url: string, body?: {}) => {
+  return await useFetch(url, Method.POST, body);
 };
 
-export const DELETE = (url: string, callBack: Function) => {
-  useFetch(url, callBack, Method.DELETE);
+export const PUT = async (url: string, body?: {}) => {
+  return await useFetch(url, Method.PUT, body);
+};
+
+export const DELETE = async (url: string) => {
+  return await useFetch(url, Method.DELETE);
 };

--- a/client/src/apis/api.ts
+++ b/client/src/apis/api.ts
@@ -1,0 +1,72 @@
+export const RES_SUCCESS: number = 200;
+export const RES_SUCCESS_REDIRECTION: number = 201;
+export const RES_FAIL: number = 400;
+export const RES_FAIL_REDIRECTION: number = 401;
+export const RES_FAIL_ALERT: number = 402;
+
+enum Method {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+}
+
+const END_POINT = 'http://localhost:8000';
+
+const useFetch = (
+  url: string,
+  callBack: Function,
+  method: Method,
+  body?: {},
+) => {
+  const option = {
+    method: method,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: body ? JSON.stringify(body) : undefined,
+  };
+
+  const URL = END_POINT + url;
+  let resStatus = RES_SUCCESS;
+
+  fetch(URL, option as RequestInit)
+    .then(res => {
+      resStatus = res.status;
+      return res.json();
+    })
+    .then((data: any) => {
+      switch (resStatus) {
+        case RES_FAIL:
+          throw new Error(data.message);
+        case RES_FAIL_REDIRECTION:
+          //window.location.href = `#${Path.signIn}`;
+          throw new Error(data.message);
+        case RES_FAIL_ALERT:
+          alert(data.message);
+          throw new Error(data.message);
+        case RES_SUCCESS:
+          callBack(data);
+          break;
+      }
+    })
+    .catch(e => {
+      console.error(e.message);
+    });
+};
+export const GET = (url: string, callBack: Function) => {
+  useFetch(url, callBack, Method.GET);
+};
+
+export const POST = (url: string, callBack: Function, body?: {}) => {
+  useFetch(url, callBack, Method.POST, body);
+};
+
+export const PUT = (url: string, callBack: Function, body?: {}) => {
+  useFetch(url, callBack, Method.PUT, body);
+};
+
+export const DELETE = (url: string, callBack: Function) => {
+  useFetch(url, callBack, Method.DELETE);
+};

--- a/client/src/components/ExampleComponent.ts
+++ b/client/src/components/ExampleComponent.ts
@@ -1,0 +1,26 @@
+import { Component } from '../lib/woowact/index';
+import { CHANGE_NUMBER, numberStore } from '../models/Number';
+
+type ExampleComponentProps = {
+  count: number;
+};
+
+export default class ExampleComponent extends Component<ExampleComponentProps> {
+  constructor(props: ExampleComponentProps) {
+    super(props);
+
+    this.init();
+  }
+
+  componentDidMount() {
+    this.$element.addEventListener('click', () => {
+      numberStore.dispatch(CHANGE_NUMBER, this.props.count);
+    });
+  }
+
+  render() {
+    return `
+      <div>${this.props.count}</div>
+    `;
+  }
+}

--- a/client/src/lib/woowact/app/App.ts
+++ b/client/src/lib/woowact/app/App.ts
@@ -11,7 +11,7 @@ export default class App extends Component {
         throw new Error(`html doesn't have #app element`);
       }
 
-      $app.appendChild(component.getElement() as Node);
+      $app.appendChild(component.$element as Node);
     } catch (e) {
       console.error(e);
     }

--- a/client/src/lib/woowact/core/Diff.ts
+++ b/client/src/lib/woowact/core/Diff.ts
@@ -1,3 +1,5 @@
+import { getArrayN } from '../../../utils/array';
+
 const getAttNameList = (attributes: NamedNodeMap): string[] => {
   if (!attributes) {
     return [];
@@ -51,25 +53,25 @@ const replaceChildren = ($origin: HTMLElement, $new: HTMLElement): void => {
 
   const max = Math.max($originChildren.length, $newChildren.length);
 
-  for (let i = 0; i < max; i++) {
+  getArrayN(max).forEach((i: number) => {
     const $originChild = $originChildren[i];
     const $newChild = $newChildren[i];
 
     if ($originChild && !$newChild) {
       $originChild.remove();
-      continue;
+      return;
     }
 
     if (!$originChild && $newChild) {
       $origin.appendChild($newChild);
-      continue;
+      return;
     }
 
     reconciliation(
       $originChildren[i] as HTMLElement,
       $newChildren[i] as HTMLElement,
     );
-  }
+  });
 };
 
 /**

--- a/client/src/lib/woowact/core/Diff.ts
+++ b/client/src/lib/woowact/core/Diff.ts
@@ -1,17 +1,114 @@
+const getAttNameList = (attributes: NamedNodeMap): string[] => {
+  if (!attributes) {
+    return [];
+  }
+
+  const attributeList: string[] = [];
+
+  Array.prototype.forEach.call(attributes, (attr: Attr) => {
+    attributeList.push(attr.nodeName);
+  });
+
+  return attributeList;
+};
+
+const replaceAttributes = ($origin: HTMLElement, $new: HTMLElement): void => {
+  const attrNames: string[] = Array.from(
+    new Set([
+      ...getAttNameList($origin.attributes),
+      ...getAttNameList($new.attributes),
+    ]),
+  );
+
+  for (const attrName of attrNames) {
+    const originAttr: string | null = $origin.getAttribute(attrName);
+    const newAttr: string | null = $new.getAttribute(attrName);
+
+    //add attribute when attribute is not exist in old element
+    //replace attribute when attributes are differnet
+    if (newAttr && (!originAttr || originAttr !== newAttr)) {
+      $origin.setAttribute(attrName, newAttr);
+      continue;
+    }
+
+    //remove attribute when attribute is not exist in new element
+    if (originAttr && !newAttr) {
+      $origin.removeAttribute(attrName);
+      continue;
+    }
+  }
+};
+
+const replaceNodeValue = ($origin: HTMLElement, $new: HTMLElement): void => {
+  if ($origin.nodeValue !== $new.nodeValue) {
+    $origin.nodeValue = $new.nodeValue;
+  }
+};
+
+const replaceChildren = ($origin: HTMLElement, $new: HTMLElement): void => {
+  const $originChildren = Array.from($origin.childNodes);
+  const $newChildren = Array.from($new.childNodes);
+
+  const max = Math.max($originChildren.length, $newChildren.length);
+
+  for (let i = 0; i < max; i++) {
+    const $originChild = $originChildren[i];
+    const $newChild = $newChildren[i];
+
+    if ($originChild && !$newChild) {
+      $originChild.remove();
+      continue;
+    }
+
+    if (!$originChild && $newChild) {
+      $origin.appendChild($newChild);
+      continue;
+    }
+
+    reconciliation(
+      $originChildren[i] as HTMLElement,
+      $newChildren[i] as HTMLElement,
+    );
+  }
+};
+
+/**
+ * reference - https://ko.reactjs.org/docs/reconciliation.html
+ *
+ * try using Heuristic algorithm
+ *
+ * @param $old (origin node)
+ * @param $new (new node)
+ * @returns $replacedElement
+ */
 const reconciliation = (
-  $old: HTMLElement | null,
+  $origin: HTMLElement,
   $new: HTMLElement,
 ): HTMLElement => {
-  if ($old === null) return $new;
+  /**
+    엘리먼트의 타입이 다른 경우
 
-  if ($old.tagName !== $new.tagName) {
-    return $new;
-  } else {
-    $old.replaceWith($new);
+    두 루트 엘리먼트의 타입이 다르면, React는 이전 트리를 버리고 완전히 새로운 트리를 구축합니다. <a>에서 <img>로, <Article>에서 <Comment>로, 혹은 <Button>에서 <div>로 바뀌는 것 모두 트리 전체를 재구축하는 경우입니다.
 
-    $old.remove();
+    트리를 버릴 때 이전 DOM 노드들은 모두 파괴됩니다. 컴포넌트 인스턴스는 componentWillUnmount()가 실행됩니다. 새로운 트리가 만들어질 때, 새로운 DOM 노드들이 DOM에 삽입됩니다. 그에 따라 컴포넌트 인스턴스는 UNSAFE_componentWillMount()가 실행되고 componentDidMount()가 이어서 실행됩니다. 이전 트리와 연관된 모든 state는 사라집니다.
+
+    루트 엘리먼트 아래의 모든 컴포넌트도 언마운트되고 그 state도 사라집니다. 예를 들어, 아래와 같은 비교가 일어나면,
+  **/
+  if ($origin.tagName !== $new.tagName) {
+    $origin.replaceWith($new);
     return $new;
   }
+
+  /*
+   * Check attributes and replace it
+   */
+  replaceAttributes($origin, $new);
+
+  replaceNodeValue($origin, $new);
+
+  replaceChildren($origin, $new);
+
+  return $origin;
 };
 
 export default { reconciliation };

--- a/client/src/lib/woowact/core/Store.ts
+++ b/client/src/lib/woowact/core/Store.ts
@@ -1,0 +1,57 @@
+import Component from './Component';
+export interface IData {
+  [key: string]: any;
+}
+
+export abstract class Store<Data extends IData> {
+  protected _data: Data;
+  protected abstract actions: { [key: string]: (args?: any) => any };
+  protected abstract updateStore: (action: string, data: any) => void;
+
+  private subscribers: Component[] = [];
+
+  constructor(data: Data) {
+    this._data = data;
+  }
+
+  public subscribe = (component: Component) => {
+    this.subscribers.push(component);
+  };
+
+  public unsubscribe = (component: Component) => {
+    this.subscribers = this.subscribers.filter(
+      subscriber => subscriber !== component,
+    );
+  };
+
+  public dispatch = (action: string, args?: any) => {
+    try {
+      if (!this.actions[action]) {
+        throw new Error(action);
+      }
+
+      this.updateStore(action, this.actions[action](args));
+
+      this.updateSubscribers();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  protected updateData = (partialData: Partial<Data>) => {
+    this._data = {
+      ...this._data,
+      ...partialData,
+    };
+  };
+
+  private updateSubscribers = () => {
+    this.subscribers.forEach((subscriber: Component) =>
+      subscriber.updateBy(this._data),
+    );
+  };
+
+  get data(): Data {
+    return this._data;
+  }
+}

--- a/client/src/lib/woowact/core/Store.ts
+++ b/client/src/lib/woowact/core/Store.ts
@@ -5,8 +5,8 @@ export interface IData {
 
 export abstract class Store<Data extends IData> {
   protected _data: Data;
-  protected abstract actions: { [key: string]: (args?: any) => any };
-  protected abstract updateStore: (action: string, data: any) => void;
+  protected abstract actions: { [key: string]: (args?: any) => Partial<Data> };
+  protected abstract updateStore: (action: string, data: Partial<Data>) => void;
 
   private subscribers: Component[] = [];
 

--- a/client/src/lib/woowact/core/myJSX.ts
+++ b/client/src/lib/woowact/core/myJSX.ts
@@ -10,7 +10,7 @@ const replaceComponent = (
   const nodeName = $current.nodeName;
 
   if (components[nodeName]) {
-    const $new = components[nodeName].getElement();
+    const $new = components[nodeName].$element;
 
     if ($new) {
       $parent.replaceChild($new, $current);

--- a/client/src/models/Number.ts
+++ b/client/src/models/Number.ts
@@ -1,0 +1,35 @@
+import { Store } from '../lib/woowact/core/Store';
+
+export const CHANGE_NUMBER = 'Number/CHANGE' as const;
+
+type NumberData = {
+  pickedNumber: number;
+};
+
+class NumberStore extends Store<NumberData> {
+  constructor(numberStore: NumberData) {
+    super(numberStore);
+  }
+
+  actions = {
+    [CHANGE_NUMBER]: this.changeCurrentNumber,
+  };
+
+  changeCurrentNumber(number: number): NumberData {
+    return {
+      pickedNumber: number,
+    };
+  }
+
+  updateStore = (action: string, args: Partial<NumberData>) => {
+    switch (action) {
+      case CHANGE_NUMBER:
+        this.updateData(args);
+        break;
+      default:
+        break;
+    }
+  };
+}
+
+export const numberStore: NumberStore = new NumberStore({ pickedNumber: 0 });

--- a/client/src/pages/ExamplePage.ts
+++ b/client/src/pages/ExamplePage.ts
@@ -1,15 +1,22 @@
+import ExampleComponent from '../components/ExampleComponent';
 import { Component } from '../lib/woowact/index';
+import { numberStore } from '../models/Number';
 
 type ExamplePageState = {
   count: number;
 };
 
 export default class ExamplePage extends Component<{}, ExamplePageState> {
+  $list: {
+    [key: string]: Component;
+  } = {};
   constructor() {
     super({});
 
+    numberStore.subscribe(this);
+
     this.state = {
-      count: 0,
+      count: 2,
     };
 
     this.init();
@@ -21,17 +28,44 @@ export default class ExamplePage extends Component<{}, ExamplePageState> {
         this.setState({
           count: this.state.count + 1,
         }),
-      1000,
-    );
-    setTimeout(
-      () =>
-        this.setState({
-          count: this.state.count + 1,
-        }),
-      3000,
+      500,
     );
   }
+
+  componentDidUpdate() {
+    if (this.state.count < 30) {
+      setTimeout(
+        () =>
+          this.setState({
+            count: this.state.count + 1,
+          }),
+        500,
+      );
+    }
+  }
+
+  generateList(): string {
+    const count = this.state.count;
+    return Array.from(Array(count).keys())
+      .map(
+        i =>
+          `<li key = ${i}>${Component._(
+            this.addComponent(ExampleComponent, { count: i }),
+          )}</li>`,
+      )
+      .join('');
+  }
+
   render(): string {
-    return `<div>${this.state.count}</div>`;
+    return `
+    <div>
+      <h1>
+        ${numberStore.data.pickedNumber} years old.
+      </h1>
+      <ul>
+        ${this.generateList()}
+        </ul>
+    </div>
+    `;
   }
 }

--- a/client/src/pages/ExamplePage.ts
+++ b/client/src/pages/ExamplePage.ts
@@ -1,6 +1,7 @@
 import ExampleComponent from '../components/ExampleComponent';
 import { Component } from '../lib/woowact/index';
 import { numberStore } from '../models/Number';
+import { getArrayN } from '../utils/array';
 
 type ExamplePageState = {
   count: number;
@@ -45,8 +46,7 @@ export default class ExamplePage extends Component<{}, ExamplePageState> {
   }
 
   generateList(): string {
-    const count = this.state.count;
-    return Array.from(Array(count).keys())
+    return getArrayN(this.state.count)
       .map(
         i =>
           `<li key = ${i}>${Component._(

--- a/client/src/utils/array.ts
+++ b/client/src/utils/array.ts
@@ -1,0 +1,3 @@
+export const getArrayN = (n: number): Array<number> => {
+  return Array.from(Array(n).keys());
+};

--- a/client/src/utils/json.ts
+++ b/client/src/utils/json.ts
@@ -1,0 +1,3 @@
+export const checkSame = (jsonA: {}, jsonB: {}): boolean => {
+  return JSON.stringify(jsonA) === JSON.stringify(jsonB);
+};

--- a/client/src/utils/parser.ts
+++ b/client/src/utils/parser.ts
@@ -1,3 +1,0 @@
-export const _ = (tag: string): string => {
-  return `<${tag}></${tag}>`;
-};


### PR DESCRIPTION
## :bookmark_tabs: 제목

가상돔 적용 및 전역 상태 관리를 위한 옵저버 패턴 적용

https://user-images.githubusercontent.com/35447853/127356719-940a9e9f-a4d4-452c-90b9-0d64b1666642.mov


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 가상돔 Diff 알고리즘 마무리 
- [x] 이벤트 핸들러 만들까 했는데 필요 없을 것 같아서 작업 안했어요~!
- [x] 전역 상태관리를 위해 옵저버 패턴을 적용했습니다 :)

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아직 코드가 일부 지저분 할 수 있습니다... 리팩토링 나중에 할게요~!
- Diff알고리즘이 완벽한지 확인이 필요합니다 (O(N^3)이기 때문에 개선 필요)
- 컴포넌트에서 자식 컴포넌트를 다룰 때 조금 불편한 점이 있어 추가 기능을 만들면 좋을 듯 합니다.
