### PR TITLE
[BE] History API 구현

### DIFF
--- a/server/src/controllers/history.controller.ts
+++ b/server/src/controllers/history.controller.ts
@@ -16,6 +16,7 @@ const MESSAGE = {
   POST_FAIL: '히스토리 생성에 실패했습니다.',
   UPDATE_FAIL: '유저 혹은 히스토리의 정보가 잘 못 입력되었습니다.',
   INVALID_DATE: '날짜 형식이 잘못 되었습니다.',
+  HISTORY_ID_NOT_EXIST: '히스토리 아이디가 잘 못 입력되었습니다.',
 };
 
 export const getHistory = async (
@@ -43,7 +44,6 @@ export const getHistory = async (
 
     HttpResponse(res, STATUS.SUCCESS, { data: history });
   } catch (e) {
-    console.error(e);
     HttpResponse(res, STATUS.FAIL, {
       message: e.message,
     });
@@ -109,9 +109,13 @@ export const deleteHistory = async (
   res: express.Response,
 ) => {
   try {
-    const userId: number = 0; // TODO: 유저 id 가지고 오기
+    const userId: number = 0; // TODO: 유저 id 가지고 오기c
 
-    const result: boolean = await removeHistory(userId, 11);
+    const historyId: number = parseInt(req.query.historyId as string);
+
+    if (isNaN(historyId)) throw new Error(MESSAGE.HISTORY_ID_NOT_EXIST);
+
+    const result: boolean = await removeHistory(userId, historyId);
 
     if (!result) throw new Error(MESSAGE.UPDATE_FAIL);
 

--- a/server/src/controllers/history.controller.ts
+++ b/server/src/controllers/history.controller.ts
@@ -1,0 +1,125 @@
+import express from 'express';
+import {
+  getHistoryList,
+  createHistory,
+  THistoryGetParams,
+  updateHistory,
+  removeHistory,
+} from '../services/history.service';
+import { STATUS, HttpResponse } from '.';
+import { IHistory } from '../models/history';
+import { checkValidDate } from '../../utils/date';
+
+const MESSAGE = {
+  GET_FAIL: '히스토리 조회에 싪패했습니다.',
+  LOGIN_REQUIRED: '로그인이 필요한 요청입니다.',
+  POST_FAIL: '히스토리 생성에 실패했습니다.',
+  UPDATE_FAIL: '유저 혹은 히스토리의 정보가 잘 못 입력되었습니다.',
+  INVALID_DATE: '날짜 형식이 잘못 되었습니다.',
+};
+
+export const getHistory = async (
+  req: express.Request,
+  res: express.Response,
+) => {
+  try {
+    let { userId, year, month, ...query } = req.query;
+
+    const currentUserId: number = null; // TODO: 유저 id 가지고 오기
+
+    if (currentUserId !== null) {
+      query.userId = currentUserId.toString();
+    }
+
+    if (!year || !month) throw new Error(MESSAGE.INVALID_DATE);
+
+    const params: THistoryGetParams = {
+      year: year as string,
+      month: month as string,
+      ...query,
+    };
+
+    const history = await getHistoryList(params);
+
+    HttpResponse(res, STATUS.SUCCESS, { data: history });
+  } catch (e) {
+    console.error(e);
+    HttpResponse(res, STATUS.FAIL, {
+      message: e.message,
+    });
+  }
+};
+
+export const postHistory = async (
+  req: express.Request,
+  res: express.Response,
+) => {
+  try {
+    const userId: number = 0; // TODO: 유저 id 가지고 오기
+
+    if (userId === null) throw new Error(MESSAGE.LOGIN_REQUIRED);
+
+    const data: IHistory = {
+      ...req.body,
+      userId,
+    }; // TODO: Need to check validation
+
+    const result: boolean = await createHistory(data);
+
+    if (!result) throw new Error(MESSAGE.POST_FAIL);
+
+    HttpResponse(res, STATUS.SUCCESS, {});
+  } catch (e) {
+    console.error(e);
+    HttpResponse(res, STATUS.FAIL, {
+      message: e.message,
+    });
+  }
+};
+
+export const putHistory = async (
+  req: express.Request,
+  res: express.Response,
+) => {
+  try {
+    const userId: number = 0; // TODO: 유저 id 가지고 오기
+
+    if (userId === null) throw new Error(MESSAGE.LOGIN_REQUIRED);
+
+    const data: IHistory = {
+      ...req.body,
+      userId,
+    }; // TODO: Need to check validation
+
+    const result: boolean = await updateHistory(data);
+
+    if (!result) throw new Error(MESSAGE.UPDATE_FAIL);
+
+    HttpResponse(res, STATUS.SUCCESS, {});
+  } catch (e) {
+    console.error(e);
+    HttpResponse(res, STATUS.FAIL, {
+      message: e.message,
+    });
+  }
+};
+
+export const deleteHistory = async (
+  req: express.Request,
+  res: express.Response,
+) => {
+  try {
+    const userId: number = 0; // TODO: 유저 id 가지고 오기
+
+    const result: boolean = await removeHistory(userId, 11);
+
+    if (!result) throw new Error(MESSAGE.UPDATE_FAIL);
+
+    HttpResponse(res, STATUS.SUCCESS, {});
+  } catch (e) {
+    console.error(e);
+    HttpResponse(res, STATUS.FAIL, {
+      message: e.message,
+    });
+  }
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,7 +13,16 @@ app.set('port', process.env.PORT || 8000);
 
 app.use(express.static('dist'));
 app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+app.use(express.urlencoded({ extended: true }));
+app.all('/*', function (req, res, next) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, DELETE');
+  res.header(
+    'Access-Control-Allow-Headers',
+    'Origin, X-Requested-With, Content-Type, Accept',
+  );
+  next();
+});
 app.use('/api/', APIRouter);
 
 app.listen(app.get('port'), () => {

--- a/server/src/models/history.ts
+++ b/server/src/models/history.ts
@@ -6,18 +6,19 @@ import {
   DataType,
   PrimaryKey,
   AllowNull,
+  AutoIncrement,
 } from 'sequelize-typescript';
 import Payment from './payment';
 import Category from './category';
 import User from './user';
 
-export interface IHistory extends Document {
+export interface IHistory {
   id?: number;
   content: string;
   amount: number;
   paymentDate: Date;
   isIncome: boolean;
-  isDeleted: boolean;
+  userId: number;
   paymentId: number;
   categoryId: number;
 }
@@ -25,6 +26,7 @@ export interface IHistory extends Document {
 @Table
 export default class History extends Model<IHistory> {
   @PrimaryKey
+  @AutoIncrement
   @Column(DataType.INTEGER)
   id: number;
 
@@ -43,10 +45,6 @@ export default class History extends Model<IHistory> {
   @AllowNull(false)
   @Column(DataType.BOOLEAN)
   isIncome: boolean;
-
-  @AllowNull(false)
-  @Column(DataType.BOOLEAN)
-  isDeleted: boolean;
 
   @AllowNull(false)
   @ForeignKey(() => User)

--- a/server/src/routers/apis/historyRouter.ts
+++ b/server/src/routers/apis/historyRouter.ts
@@ -1,25 +1,16 @@
-import { Router } from 'express';
+import express, { Router } from 'express';
+import {
+  deleteHistory,
+  putHistory,
+  postHistory,
+  getHistory,
+} from '../../controllers/history.controller';
 
 const historyRouter = Router();
 
-historyRouter.get('/', (req, res) => {
-  console.log(req.method);
-  res.status(200).json({ message: '' });
-});
-
-historyRouter.post('/', (req, res) => {
-  console.log(req.method);
-  res.status(200).json({ message: '' });
-});
-
-historyRouter.put('/', (req, res) => {
-  console.log(req.method);
-  res.status(200).json({ message: '' });
-});
-
-historyRouter.delete('/', (req, res) => {
-  console.log(req.method);
-  res.status(200).json({ message: '' });
-});
+historyRouter.get('/', getHistory);
+historyRouter.post('/', postHistory);
+historyRouter.put('/', putHistory);
+historyRouter.delete('/', deleteHistory);
 
 export default historyRouter;

--- a/server/src/services/history.service.ts
+++ b/server/src/services/history.service.ts
@@ -36,9 +36,16 @@ export type THistoryGetParams = {
   month: string;
 };
 
+const getIHistoryList = (histories: History[]): IHistory[] => {
+  return histories.map((history: any) => {
+    history.dataValues.amount = parseInt(history.dataValues.amount);
+    return history.dataValues;
+  });
+};
+
 export const getHistoryList = async (
   params: THistoryGetParams,
-): Promise<History[] | Error> => {
+): Promise<IHistory[] | Error> => {
   const { year, month, ...where } = params;
 
   const yearNumber = parseInt(year);
@@ -60,7 +67,8 @@ export const getHistoryList = async (
     },
   });
 
-  return historyList;
+  const h = getIHistoryList(historyList);
+  return h;
 };
 
 export const updateHistory = async (params: IHistory): Promise<boolean> => {

--- a/server/src/services/history.service.ts
+++ b/server/src/services/history.service.ts
@@ -1,0 +1,108 @@
+import { Op } from 'sequelize';
+import { env } from 'process';
+import History, { IHistory } from '../models/history';
+///// For test
+const makeNewData = (needId: boolean): IHistory => {
+  const contents = [
+    '국밥',
+    '순대',
+    '치킨',
+    '피자',
+    '햄버거',
+    '라멘',
+    '돈가스',
+    '떡볶이',
+  ];
+  if (env.MODE === 'develop') {
+    return {
+      id: needId ? Math.floor(Math.random() * 10) : null,
+      userId: 0,
+      content: contents[Math.floor(Math.random() * 10) % contents.length],
+      amount: Math.floor(Math.random() * 100) * 100,
+      paymentDate: new Date(),
+      isIncome: false,
+      paymentId: 0,
+      categoryId: Math.floor(Math.random() * 10) + 1,
+    };
+  }
+  throw new Error('데이터가 비었음!!');
+};
+
+export type THistoryGetParams = {
+  userId?: number;
+  category?: string;
+  isIncome?: boolean;
+  year: string;
+  month: string;
+};
+
+export const getHistoryList = async (
+  params: THistoryGetParams,
+): Promise<History[] | Error> => {
+  const { year, month, ...where } = params;
+
+  const yearNumber = parseInt(year);
+  const monthNumber = parseInt(month);
+
+  const nextMonth = monthNumber + 1 > 12 ? 1 : monthNumber + 1;
+  const nextYear = nextMonth === 1 ? yearNumber + 1 : yearNumber;
+
+  if (isNaN(yearNumber) || isNaN(monthNumber)) throw new Error('invalid date');
+
+  const historyList: History[] = await History.findAll({
+    where: {
+      ...where,
+      paymentDate: {
+        //TODO: 하드코딩(?) 되어있어요... new Date()가 로컬 시간을 받아와서 문제가 생기는데 해결을 해야합니다
+        [Op.gte]: new Date(`${year}-${month}-01 09:00:00`),
+        [Op.lt]: new Date(`${nextYear}-${nextMonth}-01 09:00:00`),
+      },
+    },
+  });
+
+  return historyList;
+};
+
+export const updateHistory = async (params: IHistory): Promise<boolean> => {
+  if (!checkHistoryCreatable) return false;
+
+  // TODO: 배포할 때 지울 것!!
+  if (!params.content) params = makeNewData(true);
+
+  //글쓴이가 origin history의 id와 다를 수 있으므로..! 체크해주기!
+  const result = await History.update(params, {
+    where: { id: params.id, userId: params.userId },
+  });
+
+  return result[0] > 0;
+};
+
+export const createHistory = async (params: IHistory): Promise<boolean> => {
+  if (!checkHistoryCreatable) return false;
+
+  // TODO: 배포할 때 지울 것!!
+  if (!params.content) params = makeNewData(false);
+
+  const result = await History.create(params);
+
+  if (result) {
+    return true;
+  }
+
+  return false;
+};
+
+const checkHistoryCreatable = (): boolean => {
+  return true;
+};
+
+export const removeHistory = async (
+  userId: number,
+  id: number,
+): Promise<boolean> => {
+  const result = await History.destroy({
+    where: { userId, id },
+  });
+
+  return result > 0;
+};

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -1,0 +1,3 @@
+export const checkValidDate = (d: Date): boolean => {
+  return d instanceof Date && !isNaN(d.getTime());
+};


### PR DESCRIPTION
## :bookmark_tabs: 제목

History API CRUD 구현 :)

![스크린샷 2021-07-30 오전 2 01 09](https://user-images.githubusercontent.com/35447853/127534142-1a88c5c1-67af-4a04-a6b8-6043209bd3e4.png)

![스크린샷 2021-07-30 오전 2 07 04](https://user-images.githubusercontent.com/35447853/127534841-f42c0c56-cd41-43fe-a5cc-fe331f4cbb2c.png)

![스크린샷 2021-07-30 오전 2 07 53](https://user-images.githubusercontent.com/35447853/127534964-04c50cd9-c9c3-4603-a3b1-df0eb9d78071.png)


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 유저 정보 있는지 체크 후 없으면 전체 유저에 대한 History 가져오기
- [x] 유저 정보 있는지 체크 후 있으면 해당 유저에 대한 History만 가져오기
- [x] year, month를 uri query로 받아서 날짜 값 비교 후 해당 연월에 해당하는 History만 가져오기
- [x] isIncome, categoryId 등의 필터데이터를 uri query로 받아서 해당 데이터에 해당하는 History만 가져오기
- [x] 업데이트나 삭제 요청 시 현재 로그인 된 유저의 정보를 확인 후 요청 진행
- [x]
 POST 요청으로 History 생성

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 날짜 비교함수가 약간의 하드코딩으로 이루어져있습니다. 서버 시간을 조정하는 등의 조치를 취해야 할 것 같아요..!
