### PR TITLE
[FE] 이벤트 핸들러 생성

### DIFF
--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -1,0 +1,71 @@
+import MainPage from './pages/MainPage';
+import ExamplePage from './pages/ExamplePage';
+import { $ } from './utils/selector';
+import Component from './lib/woowact/core/Component';
+import Link, { Route, Router } from './lib/woowact/core/Router';
+
+export default class App extends Component {
+  $app: HTMLElement;
+
+  LinkTo1: Component;
+  LinkTo2: Component;
+
+  constructor() {
+    super({});
+
+    this.LinkTo1 = this.addComponent(Link, { to: '1' });
+    this.LinkTo2 = this.addComponent(Link, { to: '2' });
+
+    this.$app = this.getRootApp();
+    this.init();
+  }
+
+  getRootApp(): HTMLElement {
+    const $app = document.getElementById('App');
+
+    if (!$app) {
+      console.error(`html doesn't have #app element`);
+    }
+
+    return $app ?? document.createElement('error');
+  }
+
+  componentDidMount() {
+    this.setEvents();
+    this.$app.append(this.$element);
+    this.setRouter();
+  }
+
+  setEvents() {
+    this.$element.addEventListener('click', (e: Event) => {
+      const aTarget = (e.target as HTMLElement).closest('.route-btn');
+      if (!aTarget) return;
+
+      window.history.pushState({}, '', '2');
+    });
+  }
+
+  setRouter() {
+    const $content = $('.content', this.$element);
+
+    if ($content) {
+      const route: Route = {
+        '/': new MainPage(),
+        '/2': new ExamplePage(),
+      };
+      new Router(route, $content);
+    }
+  }
+
+  render(): string {
+    return `<div>
+    <nav>
+      <ul>
+        ${Component._(this.LinkTo1)}
+        ${Component._(this.LinkTo2)}
+      </ul>
+    </nav>
+    <div class='content'></div>
+    </div>`;
+  }
+}

--- a/client/src/components/History/historyItem.ts
+++ b/client/src/components/History/historyItem.ts
@@ -1,4 +1,5 @@
 import { IHistory, removeHistoryAPI } from '../../apis/historyAPI';
+import { eventHandler } from '../../lib/woowact/core/EventHandler';
 import { Component } from '../../lib/woowact/index';
 import { DELETE_HISTORY, historyStore } from '../../stores/History';
 import { toWonForm } from '../../utils/money';
@@ -26,39 +27,50 @@ export default class HistoryItem extends Component<
     this.init();
   }
 
+  componentDidMount() {
+    this.addEvents();
+  }
+
+  componentDidUpdate() {
+    this.addEvents();
+  }
+
   addEvents() {
     const $editBTN = $('.edit-btn', this.$element);
     const $deleteBTN = $('.delete-btn', this.$element);
     const $editConrifmBTN = $('.confirm-btn', this.$element);
     const $cancelBTN = $('.cancel-btn', this.$element);
 
-    $editBTN?.addEventListener('click', () =>
-      this.setState({
-        editMode: true,
-      }),
-    );
-    $editConrifmBTN?.addEventListener('click', () =>
-      this.setState({
-        editMode: false,
-      }),
-    );
-    $deleteBTN?.addEventListener('click', () =>
-      historyStore.dispatch(DELETE_HISTORY, this.props.history.id),
-    );
-    $cancelBTN?.addEventListener('click', () =>
-      this.setState({ editMode: false }),
-    );
-  }
+    $editBTN &&
+      eventHandler.addEvent($editBTN, 'click', () =>
+        this.setState({
+          editMode: true,
+        }),
+      );
 
-  async updateHistory() {}
+    $editConrifmBTN &&
+      eventHandler.addEvent($editConrifmBTN, 'click', () =>
+        this.setState({
+          editMode: false,
+        }),
+      );
 
-  componentDidMount() {
-    this.addEvents();
+    $deleteBTN &&
+      eventHandler.addEvent($deleteBTN, 'click', () => {
+        console.log(this.props.history.id);
+        historyStore.dispatch(DELETE_HISTORY, this.props.history.id);
+      });
+
+    $cancelBTN &&
+      eventHandler.addEvent($cancelBTN, 'click', () =>
+        this.setState({ editMode: false }),
+      );
   }
 
   getDateString(date: Date) {
     return date.toString().slice(0, 10);
   }
+
   render() {
     if (this.state.editMode) {
       return `
@@ -88,7 +100,7 @@ export default class HistoryItem extends Component<
       <div>${this.props.history.isIncome ? '입금' : '출금'}
       ${toWonForm(this.props.history.amount)}
     </div>
-      <button class='edit-btn'>수정</button>
+      <button class='edit-confirm-btn'>수정</button>
       <button class='delete-btn'>삭제</button>
     </div>
     `;

--- a/client/src/lib/woowact/core/Component.ts
+++ b/client/src/lib/woowact/core/Component.ts
@@ -1,7 +1,6 @@
 import { checkSame } from '../../../utils/json';
 import Diff from './Diff';
 import { parseJSX } from './myJSX';
-import { Store } from './Store';
 
 export interface PropsType {}
 export interface StateType {}
@@ -14,7 +13,7 @@ export type ComponentId = string;
 
 const TAG: string = 'C-';
 
-export default class Component<
+export default abstract class Component<
   P extends PropsType = PropsType,
   S extends StateType = StateType,
 > {
@@ -38,8 +37,12 @@ export default class Component<
 
   // this should be called in constructor of 'Child Class Component'
   protected init() {
-    this._$element = parseJSX(this.render(), this.$components);
+    this._$element = this.$newElement;
     this.componentDidMount();
+  }
+
+  private get $newElement() {
+    return parseJSX(this.render(), this.$components);
   }
 
   get $element(): HTMLElement {
@@ -54,7 +57,7 @@ export default class Component<
     } catch (e) {
       console.error(e.message);
 
-      //it doen't work
+      //it doesn't work
       return document.createElement('error');
     }
   }
@@ -70,23 +73,19 @@ export default class Component<
     return newComponent;
   }
 
-  protected render(): string {
-    throw new Error('need to be implemented');
-  }
+  protected abstract render(): string;
 
   private update(): void {
     try {
-      const $new = parseJSX(this.render(), this.$components);
-
       if (this._$element === null) {
-        this._$element = $new;
+        this._$element = this.$newElement;
 
         throw new Error(
           `component doesn't have element. please call init() in its constructor.`,
         );
       }
 
-      this._$element = Diff.reconciliation(this.$element, $new);
+      this._$element = Diff.reconciliation(this.$element, this.$newElement);
       this.componentDidUpdate();
     } catch (e) {
       console.error(e);

--- a/client/src/lib/woowact/core/Diff.ts
+++ b/client/src/lib/woowact/core/Diff.ts
@@ -1,5 +1,9 @@
 import { getArrayN } from '../../../utils/array';
 
+type TKeyElement = {
+  [key: string]: Element;
+};
+
 const getAttNameList = (attributes: NamedNodeMap): string[] => {
   if (!attributes) {
     return [];
@@ -48,6 +52,52 @@ const replaceNodeValue = ($origin: HTMLElement, $new: HTMLElement): void => {
 };
 
 const replaceChildren = ($origin: HTMLElement, $new: HTMLElement): void => {
+  if ($origin.tagName === 'UL' || $origin.tagName === 'OL') {
+    replaceByKeys($origin, $new);
+    return;
+  }
+
+  replaceStartToEnd($origin, $new);
+};
+
+const getKeyNodes = ($element: HTMLElement): { [key: number]: Element } => {
+  const keyNodes: TKeyElement = {};
+  Array.from($element.children).forEach(child => {
+    const key: string | null = (child as HTMLElement).getAttribute('key');
+
+    if (!key) {
+      console.error('child component must have key');
+      return;
+    }
+
+    keyNodes[key] = child as HTMLElement;
+  });
+  return keyNodes;
+};
+
+const replaceByKeys = ($origin: HTMLElement, $new: HTMLElement) => {
+  const $originKeyNodes: TKeyElement = getKeyNodes($origin);
+  const newKeyArray = Array.from($new.children);
+
+  $origin.innerHTML = '';
+
+  newKeyArray.forEach(child => {
+    const key: string | null = (child as HTMLElement).getAttribute('key');
+
+    if (!key) {
+      console.error('child component must have key');
+      return;
+    }
+
+    if ($originKeyNodes[key]) {
+      $origin.appendChild($originKeyNodes[key]);
+    } else {
+      $origin.appendChild(child);
+    }
+  });
+};
+
+const replaceStartToEnd = ($origin: HTMLElement, $new: HTMLElement) => {
   const $originChildren = Array.from($origin.childNodes);
   const $newChildren = Array.from($new.childNodes);
 
@@ -98,6 +148,7 @@ const reconciliation = (
   **/
   if ($origin.tagName !== $new.tagName) {
     $origin.replaceWith($new);
+    $origin.remove();
     return $new;
   }
 

--- a/client/src/lib/woowact/core/EventHandler.ts
+++ b/client/src/lib/woowact/core/EventHandler.ts
@@ -1,0 +1,68 @@
+type HTMLEventCallback = (
+  this: HTMLElement,
+  ev:
+    | Event
+    | UIEvent
+    | AnimationEvent
+    | MouseEvent
+    | InputEvent
+    | FocusEvent
+    | CompositionEvent,
+) => any;
+
+type TEventCallbacks = {
+  [event: string]: HTMLEventCallback;
+};
+
+declare global {
+  interface HTMLElement {
+    eTarget?: number;
+  }
+}
+
+export const E_TARGET = 'e-target';
+
+class EventHandler {
+  static id: number = 0;
+
+  events: {
+    [target: string]: TEventCallbacks;
+  };
+
+  constructor() {
+    this.events = {};
+  }
+
+  private getTargetID($el: HTMLElement): number {
+    if ($el.eTarget) return $el.eTarget;
+
+    $el.eTarget = EventHandler.id++;
+
+    this.events[$el.eTarget] = {};
+
+    return $el.eTarget;
+  }
+
+  public addEvent(
+    $target: HTMLElement,
+    event: keyof HTMLElementEventMap,
+    callback: HTMLEventCallback,
+  ) {
+    const target = this.getTargetID($target);
+
+    //관련 event 안에 해당하는 앨리먼트 - callback 가 매칭되는 게 없을 때
+    if (this.checkCallbackExist(target, event)) {
+      $target.removeEventListener(event, this.events[target][event]);
+    }
+
+    this.events[target][event] = callback;
+
+    $target.addEventListener(event, callback);
+  }
+
+  private checkCallbackExist(target: number, event: string) {
+    return this.events[target][event];
+  }
+}
+
+export const eventHandler: EventHandler = new EventHandler();

--- a/client/src/lib/woowact/core/Store.ts
+++ b/client/src/lib/woowact/core/Store.ts
@@ -5,10 +5,8 @@ export interface IData {
 
 export abstract class Store<Data extends IData> {
   protected _data: Data;
-  protected abstract actions: {
-    [key: string]: (args?: any) => Partial<Data> | Promise<Partial<Data>>;
-  };
-  protected abstract updateStore: (action: string, data: Partial<Data>) => void;
+  protected abstract actions: { [key: string]: (args?: any) => any };
+  protected abstract updateStore: (action: string, data: any) => void;
 
   private subscribers: Component[] = [];
 
@@ -26,20 +24,13 @@ export abstract class Store<Data extends IData> {
     );
   };
 
-  public dispatch = async (action: string, args?: any) => {
+  public dispatch = (action: string, args?: any) => {
     try {
       if (!this.actions[action]) {
         throw new Error(action);
       }
 
-      const updatedData = this.actions[action](args);
-
-      if (updatedData instanceof Promise) {
-        const data = await this.actions[action](args);
-        this.updateStore(action, data);
-      } else {
-        this.updateStore(action, updatedData);
-      }
+      this.updateStore(action, this.actions[action](args));
 
       this.updateSubscribers();
     } catch (e) {

--- a/client/src/pages/ExamplePage.ts
+++ b/client/src/pages/ExamplePage.ts
@@ -34,6 +34,9 @@ export default class ExamplePage extends Component<{}, ExamplePageState> {
   }
 
   componentDidUpdate() {
+    this.$element.addEventListener('click', () => {
+      console.log('AA');
+    });
     if (this.state.count < 30) {
       setTimeout(
         () =>

--- a/client/src/pages/MainPage.ts
+++ b/client/src/pages/MainPage.ts
@@ -1,9 +1,11 @@
 import HistoryItem from '../components/History/HistoryItem';
+import { eventHandler } from '../lib/woowact/core/EventHandler';
 import { Component } from '../lib/woowact/index';
 import { historyStore } from '../stores/History';
 import { getArrayN } from '../utils/array';
 
 export default class MainPage extends Component<{}, {}> {
+  count = 0;
   constructor() {
     super({});
 
@@ -12,11 +14,17 @@ export default class MainPage extends Component<{}, {}> {
     this.init();
   }
 
+  componentDidUpdate() {
+    eventHandler.addEvent(this.$element, 'click', () => {
+      console.log(historyStore.data.histories.length);
+    });
+  }
+
   generateList(): string {
     return getArrayN(historyStore.data.histories.length)
       .map(
         i =>
-          `<li key = ${i}>${Component._(
+          `<li key = ${historyStore.data.histories[i].id}>${Component._(
             this.addComponent(HistoryItem, {
               history: historyStore.data.histories[i],
             }),


### PR DESCRIPTION
## :bookmark_tabs: 제목

컴포넌트에서 이벤트를 등록할 때 중복으로 이벤트가 생성되지 않도록 관리해주는 이벤트 핸들러를 만들었습니다 :)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 이벤트 핸들러 생성
- [x] 이벤트 핸들러 테스트

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 컴포넌트에서 특정 엘리먼트에 이벤트를 등록하고 싶을때에는 반드시 eventHandler.addEvent를 통해 이벤트를 등록해주세요!
